### PR TITLE
Bugfix/return null if no organizers

### DIFF
--- a/includes/connection/class-organizers.php
+++ b/includes/connection/class-organizers.php
@@ -11,7 +11,12 @@
 namespace WPGraphQL\QL_Events\Connection;
 
 use Tribe__Events__Main as Main;
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
 use WPGraphQL\Connection\PostObjects;
+use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
+
+
 
 /**
  * Class - Organizers
@@ -29,6 +34,12 @@ class Organizers extends PostObjects {
 					'fromType'      => 'Event',
 					'toType'        => 'Organizer',
 					'fromFieldName' => 'organizers',
+					'resolve'       => function( $source, array $args, AppContext $context, ResolveInfo $info ){
+						$organizer_ids = tribe_get_organizer_ids($source->ID);
+						$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, Main::ORGANIZER_POST_TYPE );
+
+						return !empty($organizer_ids) ? $resolver->get_connection() : null;
+					}
 				)
 			)
 		);

--- a/includes/connection/class-organizers.php
+++ b/includes/connection/class-organizers.php
@@ -34,11 +34,11 @@ class Organizers extends PostObjects {
 					'fromType'      => 'Event',
 					'toType'        => 'Organizer',
 					'fromFieldName' => 'organizers',
-					'resolve'       => function( $source, array $args, AppContext $context, ResolveInfo $info ){
-						$organizer_ids = tribe_get_organizer_ids($source->ID);
+					'resolve'       => function( $source, array $args, AppContext $context, ResolveInfo $info ) {
+						$organizer_ids = tribe_get_organizer_ids( $source->ID );
 						$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, Main::ORGANIZER_POST_TYPE );
 
-						return !empty($organizer_ids) ? $resolver->get_connection() : null;
+						return ! empty( $organizer_ids ) ? $resolver->get_connection() : null;
 					}
 				)
 			)


### PR DESCRIPTION
This PR fixes `organizers` so it returns null if no organizers are set for the event. 
Fixes #13 