### PR TITLE
Removes extraneous comma to prevent a silent PHP error.

### DIFF
--- a/includes/types/object/class-event-type.php
+++ b/includes/types/object/class-event-type.php
@@ -243,7 +243,7 @@ class Event_Type {
 										case '<':
 											return $left_date < $right_date;
 									}
-								},
+								}
 							);
 						}
 


### PR DESCRIPTION
Minor fix from a jam session to figure out what was causing an error and preventing event data from GraphiQL with newer versions of PHP.